### PR TITLE
fix(d4): the locked launcher can never start the BBS — three fatal errors in the one exec, and the audit log records it as started

### DIFF
--- a/config/launchers/eniqma-locked.conf
+++ b/config/launchers/eniqma-locked.conf
@@ -16,7 +16,14 @@
 # is the catch-all.
 #
 #   /AutoPPP/ -  -  /usr/sbin/pppd file /etc/ppp/options.ttyACM0
-#   *          -  -  /usr/local/bin/eniqma-locked
+#   *          -  -  /usr/local/bin/eniqma-locked --jail-root /var/lib/bbs/jail --bbs-user bbs --bbs-group bbs --audit-log /var/log/bbs-launcher/audit.jsonl
+#
+# The launcher reads NO environment and NO config file — that is the
+# point of the wrapper (a captive user must not be able to influence it
+# through mgetty's environment).  So the values below are documentation
+# of the defaults; to change one, pass the matching flag on the rule
+# above.  `eniqma-locked --print-argv` shows the resulting
+# systemd-nspawn command line without starting anything.
 
 # Audit log lives outside the jail so a captive user cannot
 # tamper with it.  Owned by root:adm mode 0640.
@@ -34,11 +41,15 @@ BBS_GROUP=bbs
 # checked by the launcher).
 JAIL_ROOT=/var/lib/bbs/jail
 
-# Maximum BBS startup time, in seconds.  Past this the
-# launcher returns EX_TEMPFAIL and mgetty hangs up.  Set
-# below to fail fast on misconfiguration.
-BBS_STARTUP_TIMEOUT=30
+# User namespace UID base for systemd-nspawn --private-users=.
+# Container UID 0 maps to this host UID, so root inside the jail is
+# nobody outside it.  Use `off` on a kernel without user namespaces.
+PRIVATE_USERS=65536
 
-# Per-TTY accounting.  If you have more than one dial-in
-# line, the launcher logs the TTY by reading /dev/tty at exec
-# time.  No further config is needed for that.
+# Per-TTY accounting.  If you have more than one dial-in line, the
+# launcher records the TTY (os.ttyname of the dial-in fd) and mgetty's
+# $CALLER_ID in every audit record.  No further config is needed.
+#
+# There is no BBS_STARTUP_TIMEOUT: the launcher waits for the container
+# for as long as the caller stays connected and records the exit status
+# it ended with.  mgetty hangs up the line when the launcher returns.

--- a/docs/D4_LOCKED_LAUNCHER.md
+++ b/docs/D4_LOCKED_LAUNCHER.md
@@ -18,8 +18,8 @@ launcher actually delivers the rubric in BOUNTIES.md.
 | Rubric clause | How this PR satisfies it |
 |---|---|
 | "BBS reachable on the terminal line" | The launcher is wired into `config/login.config` as the terminal-mode fallback. After mgetty prints a "CONNECT" and waits for LCP, if no LCP comes in the window, mgetty execs the launcher per the `/etc/mgetty/login.config` rule in `config/launchers/eniqma-locked.conf`. |
-| "via an unprivileged launcher" | `_lookup_unprivileged_user()` refuses UID 0. The launcher then `os.execv()`s `systemd-nspawn` with `--user=<bbs_uid> --group=<bbs_gid>`, so the BBS process never runs as root. |
-| "no host shell escape" | Covered by `tests/test_eniqma_locked.py` (13 cases, all passing). Specifically: missing jail refused, symlinked jail refused, symlinked canonical file refused, symlinked audit log refused, $SHELL ignored, session-id sanitised, audit-log append-only, audit-log mode 0640. |
+| "via an unprivileged launcher" | `_lookup_unprivileged_user()` refuses UID 0 (host-side guard), `_jail_user_uid()` refuses a jail account that is UID 0 inside the jail, and the container is run with `--user=<name>`, which `systemd-nspawn` resolves in the **jail's** `/etc/passwd` — that is what makes the BBS process non-root. `systemd-nspawn` has no `--group=` option; the gid comes from the same jail passwd entry. The launcher itself stays root until the fork because building the namespaces needs `CAP_SYS_ADMIN`. |
+| "no host shell escape" | Covered by `tests/test_eniqma_locked.py` (13 cases) + `tests/test_eniqma_locked_exec.py` (37 cases covering everything `--dry-run` skips). Specifically: missing jail refused, symlinked jail refused, symlinked canonical file refused, symlinked audit log refused, $SHELL ignored, session-id sanitised, audit-log append-only, audit-log mode 0640. |
 | "OS accounts ≠ BBS accounts" | The launcher's only privilege model is a separate unprivileged user (default `bbs`, UID ≥ 1). The /etc/passwd inside the jail is independent of the host /etc/passwd. |
 | "Include the launcher" | `launchers/eniqma-locked.py` (411 lines, type-hinted, no third-party deps). |
 | "a documented escape-attempt test" | `tests/test_eniqma_locked.py` (13 cases) + this document + inline comments in the launcher (`# Escape-attempt contract` block). |
@@ -30,7 +30,8 @@ launcher actually delivers the rubric in BOUNTIES.md.
 launchers/eniqma-locked.py          # the launcher (Python 3.10+)
 launchers/eniqma-locked.service     # systemd unit reference
 config/launchers/eniqma-locked.conf # mgetty login.config snippet
-tests/test_eniqma_locked.py         # 13 escape-attempt tests
+tests/test_eniqma_locked.py         # 13 escape-attempt tests (--dry-run)
+tests/test_eniqma_locked_exec.py    # 37 tests of the container path
 docs/D4_LOCKED_LAUNCHER.md          # this file
 ```
 
@@ -107,17 +108,53 @@ The order of rules in `login.config` is significant.  `/AutoPPP/`
 must precede `*`.  See the parent `config/login.config` for the
 documented layout.
 
+### 3.6 What actually gets run
+
+The launcher never execs a shell and never execs `$SHELL`.  It builds
+one fixed argv and runs it as a child, so it can write the closing
+audit record:
+
+```bash
+/usr/local/bin/eniqma-locked --print-argv          # review it before dialling in
+/usr/bin/systemd-nspawn --quiet --as-pid2 --machine=bbs-<session> \
+    --directory=/var/lib/bbs/jail --private-users=65536 --user=bbs \
+    -- /usr/bin/env -i HOME=/bbs TERM=dumb node /bbs/enigma-bbs.js
+```
+
+Two things about that line are easy to get wrong and both make it
+unrunnable: `systemd-nspawn` has **no** `--group=` option (it dies with
+`unrecognized option`), and `--boot` **may not be combined with
+`--as-pid2`** — `--boot` would run the container's init and pass the
+trailing words to it as kernel-command-line arguments instead of
+executing them.  `tests/test_eniqma_locked_exec.py` checks the argv
+against the real option table.
+
+`--private-users=65536` maps container UID 0 to host UID 65536, so root
+inside the jail is nobody outside it.  The jail tree must be readable by
+the shifted range; pass `--private-users off` if the operator's kernel
+has user namespaces disabled, or shift the tree once with
+`systemd-nspawn --private-users=65536 --private-users-ownership=chown`.
+
+The audit log gets one `start` record and then exactly one of `exit`
+(with the container's status), `exec_failed` (the container manager
+could not be executed at all) or `refused` (validation failed before
+anything ran).  A `start` with no closing record means the launcher
+itself was killed.
+
 ## 4. Reviewer test recipe
 
 The test suite is the contract.  It runs without sudo and without
 network access:
 
 ```bash
-cd /opt/hermes-bounty-ops/workspaces/rustchain-dialup/dialup-d4
-python3 -m pytest tests/test_eniqma_locked.py -v
+python3 -m pytest tests/test_eniqma_locked.py tests/test_eniqma_locked_exec.py -v
 ```
 
-Expected output: `13 passed in <1s`.  Each test name is a
+Expected output: `50 passed in <2s`.  The first file drives the
+launcher as a subprocess with `--dry-run`; the second one covers the
+part `--dry-run` returns before — the `systemd-nspawn` argv, the
+machine name, jail validation against a real merged-`/usr` rootfs, and
+the audit records written when the container ends.  Each test name is a
 self-documenting claim about the launcher's contract.  If you are
 reviewing a patch to the launcher, the test that fails is the one
 that broke.  The tests are:
@@ -151,13 +188,13 @@ is mapped to the test that proves it.
 
 | Attempt | What a captive user might try | What stops it |
 |---|---|---|
-| **Swap the jail root for `/home`** | Symlink `/var/lib/bbs/jail` to `/home` so the launcher reads host user files | `_validate_jail` rejects any symlink in the path (`test_refuses_symlinked_jail_root`) |
-| **Replace the BBS binary with a shell** | Symlink `/bbs/enigma-bbs.js` to `/bin/sh` | `_validate_jail` rejects any symlink in the canonical paths (`test_refuses_symlinked_canonical_file`) |
+| **Swap the jail root for `/home`** | Symlink `/var/lib/bbs/jail` to `/home` so the launcher reads host user files | `_validate_jail` walks every real component from `/` down to the jail root and rejects a symlink at any of them (`test_refuses_symlinked_jail_root`, `test_symlinked_ancestor_of_the_jail_is_rejected`) |
+| **Replace the BBS binary with a shell** | Symlink `/bbs/enigma-bbs.js` to `/bin/sh` | `_validate_jail` rejects a canonical file whose symlink resolves **outside** the jail (`test_refuses_symlinked_canonical_file`). Links that stay inside are normal — `bin/sh -> dash` and `lib -> usr/lib` ship in every Debian rootfs (`test_merged_usr_rootfs_is_accepted`) |
 | **Drop the audit log to /dev/null** | Symlink the audit log to `/dev/null` after first session | `_ensure_audit_log` checks for symlinks before open and refuses to follow them (`test_refuses_audit_log_symlink`) |
 | **Inject `$SHELL` from the dial-in prompt** | Send `SHELL=/bin/bash` via Telnet NAWS or similar | The launcher's safe-env allow-list only includes `TERM` and `LANG`; the captured env is recorded in the audit log so an operator can grep for tampering (`test_shell_env_var_does_not_affect_launcher`) |
 | **Run a hostile bbs user** | Have the operator set `--bbs-user=root` by accident | The launcher refuses UID 0 (`test_root_bbs_user_refuses`) and refuses unknown users (`test_unknown_bbs_user_refuses`) |
 | **TOCTOU swap of canonical files** | Race the launcher's open() by replacing a canonical file with a symlink between resolve() and open() | `_validate_jail` re-checks each canonical file with `Path.is_symlink()` after the existence check (`test_refuses_symlinked_canonical_file` is the closest test; full TOCTOU protection would also require a `chflags` lockdown on the jail, which is operator-side) |
-| **Trick `execve` into running something else** | Set a magic env var or argv injection | `os.execv` is called with a fixed argv literal; the launcher has no `eval`/`subprocess.Popen(shell=True)` anywhere; the only env vars forwarded into the nspawn container are `HOME` and `TERM` (constants in the source) |
+| **Trick `execve` into running something else** | Set a magic env var or argv injection | `build_nspawn_argv()` returns a fixed argv (asserted free of shell metacharacters by `test_argv_runs_the_bbs_as_the_container_payload`, and printable for review with `--print-argv`); the launcher has no `eval`/`subprocess.Popen(shell=True)` anywhere; the only env vars forwarded into the nspawn container are `HOME` and `TERM` (constants in the source) |
 
 ## 6. What this PR does NOT do
 
@@ -170,6 +207,15 @@ not:
 - Handle ANSI/UTF-8 negotiation.  ENiGMA½ does that itself.
 - Implement rate limiting or DoS protection.  That belongs in
   the firewall (see the existing `nftables-dialup.conf`).
+- Bind a writable data directory into the jail.  ENiGMA½ message
+  bases therefore live inside the jail tree, not in a separate
+  `/var/lib/bbs/data`; adding `--bind=` is an operator/maintainer
+  decision (and interacts with `--private-users` ownership), so it is
+  deliberately not done here.
+- Read `config/launchers/eniqma-locked.conf` as a config file.  The
+  launcher takes no environment and no config file by design; that
+  snippet documents the mgetty rule, and the values are passed as
+  flags on that rule.
 - Implement any backdoor.  The audit log records every
   attempt to start, succeed, refuse, or fail.  An operator
   can `grep '"event": "refused"' /var/log/bbs-launcher/audit.jsonl`

--- a/launchers/eniqma-locked.py
+++ b/launchers/eniqma-locked.py
@@ -1,43 +1,55 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
-# SPDX-License-Identifier: MIT
 #
 # launchers/eniqma-locked.py — Bounty D4 "ENiGMA½ locked launcher"
 #
 # The lock-down boundary between a dial-in mgetty session and a host
 # shell. Invoked by mgetty's `/etc/mgetty/login.config` fallback (or
 # directly by an SSH `bbs` user for testing) and is the ONLY program a
-# dial-in user can ever reach.  After privilege-drop, the launcher:
+# dial-in user can ever reach.  After validation, the launcher:
 #
-#   1. Records the session (TTY, peer addr, start time) to a dedicated
+#   1. Records the session (TTY, caller id, start time) to a dedicated
 #      audit log owned by `root:adm` (mode 0640) so a captive BBS user
 #      cannot tamper with or silently drop their own audit trail.
 #   2. Validates the BBS jail root (default `/var/lib/bbs/jail`) and
 #      refuses to start if the jail is missing the canonical structure
-#      (no node binary, no /etc/passwd inside the jail).  No fallback
-#      to a host shell is ever taken — a broken jail means the user
-#      gets a clear `503` banner and a hung line, not an escape.
-#   3. Drops to the unprivileged `bbs` user (UID 999 in the
-#      /etc/passwd that ships with the jail), gives up root, then
-#      execs `systemd-nspawn --as-pid2 --private-users=65536
-#      --user=bbs --chdir=/var/lib/bbs --bind=/var/lib/bbs/data
-#      --machine=BBS<short-id> -- /usr/bin/env node /bbs/enigma-bbs.js`
-#      so the BBS runs as a child of init inside a mount/PID/user
-#      namespace with no visibility of the host filesystem, no path
-#      to launch a host process, and no way to `chroot` out (the
-#      outer namespace still owns the real root).
-#   4. Waits for the BBS to exit and records the exit code.  It does
-#      NOT interpret the exit code (no "fallback to bash" branch).
+#      (no node binary, no /etc/passwd inside the jail), if any real
+#      ANCESTOR of the jail root is a symlink, or if a canonical file
+#      is a symlink that leaves the jail.  No fallback to a host shell
+#      is ever taken — a broken jail means the user gets a clear `503`
+#      banner and a hung line, not an escape.
+#   3. Forks and runs `systemd-nspawn --quiet --as-pid2
+#      --machine=bbs-<short-id> --directory=<jail>
+#      --private-users=65536 --user=bbs -- /usr/bin/env -i HOME=/bbs
+#      TERM=dumb node /bbs/enigma-bbs.js` so the BBS runs as PID 2
+#      inside a mount/PID/user namespace with no visibility of the
+#      host filesystem, no path to launch a host process, and no way
+#      to `chroot` out (the outer namespace still owns the real root).
+#   4. Waits for the BBS to exit, forwards a hangup/termination signal
+#      to it exactly once, and records the exit code.  It does NOT
+#      interpret the exit code (no "fallback to bash" branch).
 #      mgetty will then hang up the line.
 #
-# Escape-attempt contract (covered by tests/test_eniqma_locked.py):
+# WHO RUNS AS WHAT (this is the part that is easy to get wrong):
+#   `systemd-nspawn` needs CAP_SYS_ADMIN to build the namespaces, so
+#   the launcher itself stays root until exec — it CANNOT setuid()
+#   first.  The unprivileged account is applied by nspawn's `--user=`,
+#   which resolves the name in the JAIL's /etc/passwd (not the host's)
+#   and is what makes the BBS process non-root.  The host-side lookup
+#   below is therefore a configuration guard + audit record, not the
+#   thing that drops privilege.  `systemd-nspawn` has no `--group=`
+#   option at all (checked against systemd 244..257); the group comes
+#   from the jail's passwd entry for `--user`.
+#
+# Escape-attempt contract (covered by tests/test_eniqma_locked.py and
+# tests/test_eniqma_locked_exec.py):
 #   - Setting $SHELL=/bin/bash has no effect — the launcher never
-#     execs $SHELL.  It always execs `systemd-nspawn` with a fixed
+#     execs $SHELL.  It always runs `systemd-nspawn` with a fixed
 #     argv that has no shell metacharacters.
 #   - Sending SIGUSR1 / SIGHUP / SIGTERM is forwarded at most once
 #     and does not produce a host shell.
-#   - Symlink attacks on the jail root are detected by `os.path.realpath`
-#     and rejected before privilege drop.
+#   - Symlink attacks on the jail root, on any ancestor of it, and on
+#     the canonical files are detected and rejected before exec.
 #   - The launcher's argv[0] is fixed; even if `execve` is patched
 #     by a kernel-level attacker, the audit log entry records the
 #     original pid and parent tty.
@@ -50,28 +62,27 @@
 #     variable and validates the jail before doing anything.
 #   - Python gives us a clean, testable audit-log format (JSONL with
 #     a fixed schema) without depending on a third-party logger.
-#   - systemd-nspawn requires `CAP_SYS_ADMIN` to set up the
-#     namespace; the wrapper holds that briefly and drops it
-#     before exec.  A shell script would have to do the same dance
-#     with setpriv / capsh and would be more error-prone.
+#   - The wrapper can wait for the container and write the closing
+#     audit record, which a bare `exec` in a shell script cannot.
 #
 # Author: Hermes (rustchain-dialup bounty executor).
 # Bounty: D4 (ENiGMA½ locked launcher, 20 RTC).
-# Wallet: TBD (Boss/Codex supplies a RustChain RTC receive address
-#         before the maintainer executes the payout).
 from __future__ import annotations
 
 import argparse
 import errno
 import fcntl
+import grp
 import json
 import os
 import pwd
+import re
+import signal
 import stat
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict, NoReturn, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 
 # --- Constants ----------------------------------------------------------------
@@ -80,9 +91,9 @@ from typing import Any, Dict, NoReturn, Optional, Sequence
 # different prefix (e.g. an LXC rootfs or a custom ENiGMA½ install).
 DEFAULT_JAIL_ROOT = Path("/var/lib/bbs/jail")
 
-# The unprivileged UID/GID the launcher drops to inside the host
-# namespace.  Must be a real, non-root system account; the wrapper
-# looks it up by name and rejects the launch if it does not exist.
+# The unprivileged account the BBS runs as.  Resolved twice: on the HOST
+# (a sanity guard — the name must exist and must not be UID 0) and inside
+# the JAIL by systemd-nspawn's --user=, which is what actually applies.
 DEFAULT_BBS_USER = "bbs"
 DEFAULT_BBS_GROUP = "bbs"
 
@@ -100,15 +111,30 @@ JAIL_CANONICAL_PATHS = (
 # root:adm.  A symlink here is treated as an escape attempt.
 DEFAULT_AUDIT_LOG = Path("/var/log/bbs-launcher/audit.jsonl")
 
-# Maximum time (seconds) we will wait for the BBS to start.  After
-# this, we treat the session as failed and return exit code 75
-# (EX_TEMPFAIL).  mgetty will then hang up.
-BBS_STARTUP_TIMEOUT = 30.0
+# The container manager.  A missing binary is a deployment error and is
+# refused (and audited) instead of being discovered as a dead line.
+NSPAWN_BIN = "/usr/bin/systemd-nspawn"
+
+# UID base for the user namespace.  `--private-users=<base>` maps
+# container UID 0 to host UID <base>, so container root is nobody on the
+# host.  Pass --private-users off to disable (e.g. on a kernel without
+# user namespaces); the jail tree must then be readable by the host uid.
+DEFAULT_PRIVATE_USERS = "65536"
 
 # Where systemd-nspawn stores the per-session machine name.  The
 # machine name is opaque to the BBS but visible in `machinectl list`,
 # which is how an operator audits "who is online right now".
+#
+# systemd validates it with machine_name_is_valid() -> hostname_is_valid():
+# labels of valid_ldh_char() only (ASCII letters, digits, '-'), '.' as a
+# separator, no leading/trailing '-' or '.', no empty label, <= 64 bytes.
+# NOTE '_' is NOT a valid_ldh_char, so it cannot appear here.
 MACHINE_NAME_PREFIX = "bbs"
+MACHINE_NAME_MAX = 64
+
+# Signals we forward to the container exactly once.  SIGHUP is the one
+# that matters in production: mgetty drops DTR when the caller hangs up.
+FORWARDED_SIGNALS = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT, signal.SIGQUIT)
 
 
 # --- Argument parsing ---------------------------------------------------------
@@ -131,12 +157,20 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--bbs-user",
         default=DEFAULT_BBS_USER,
-        help="unprivileged host account to drop to (default: %(default)s)",
+        help=(
+            "unprivileged account the BBS runs as.  Must exist on the "
+            "host (guard) AND in the jail's /etc/passwd, which is the "
+            "one systemd-nspawn resolves (default: %(default)s)"
+        ),
     )
     p.add_argument(
         "--bbs-group",
         default=DEFAULT_BBS_GROUP,
-        help="unprivileged host group to drop to (default: %(default)s)",
+        help=(
+            "host group recorded in the audit log (default: %(default)s). "
+            "systemd-nspawn has no --group option; the container gid comes "
+            "from the jail's passwd entry for --bbs-user."
+        ),
     )
     p.add_argument(
         "--audit-log",
@@ -145,12 +179,26 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="path to the audit log JSONL file (default: %(default)s)",
     )
     p.add_argument(
+        "--private-users",
+        default=DEFAULT_PRIVATE_USERS,
+        help=(
+            "value for systemd-nspawn --private-users= (UID base, "
+            "'pick', or 'off' to disable user namespacing; "
+            "default: %(default)s)"
+        ),
+    )
+    p.add_argument(
         "--dry-run",
         action="store_true",
         help=(
             "validate the jail + write the audit entry but do NOT "
-            "exec systemd-nspawn.  Used by the test harness."
+            "run systemd-nspawn.  Used by the test harness."
         ),
+    )
+    p.add_argument(
+        "--print-argv",
+        action="store_true",
+        help="print the exact systemd-nspawn argv that would be run, one per line, and exit",
     )
     p.add_argument(
         "--session-id",
@@ -175,23 +223,39 @@ def _ensure_audit_log(path: Path) -> None:
         raise PermissionError(f"audit log {path} is a symlink; refusing to follow it")
     parent = path.parent
     parent.mkdir(parents=True, exist_ok=True)
-    if not path.exists():
-        # O_CREAT | O_EXCL would be safer, but rotating audit logs
-        # is a separate concern.  We open with O_APPEND so existing
-        # entries are never truncated.
+    try:
+        # O_EXCL|O_NOFOLLOW: we either create it ourselves or we inspect
+        # what is already there.  O_APPEND so existing entries are never
+        # truncated.
         fd = os.open(
             str(path),
-            os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_CLOEXEC,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_APPEND | os.O_CLOEXEC | os.O_NOFOLLOW,
             0o640,
         )
-        os.close(fd)
-    st = path.stat()
+    except FileExistsError:
+        pass
+    else:
+        try:
+            # The open() mode argument is masked by umask (mgetty runs with
+            # 022 or 077 depending on the distro), so set it explicitly.
+            os.fchmod(fd, 0o640)
+        finally:
+            os.close(fd)
+
+    # lstat, NOT stat: stat() follows the link, so S_ISLNK on its result
+    # can never be true and the TOCTOU check would be dead code.
+    st = os.lstat(str(path))
     if stat.S_ISLNK(st.st_mode):
         raise PermissionError(f"audit log {path} became a symlink between checks")
-    if st.st_mode & 0o077:
-        # Group/other readable.  Reset to 0640.  We do not fail
-        # the launch over this; an operator can fix it offline.
-        os.chmod(path, 0o640)
+    if not stat.S_ISREG(st.st_mode):
+        raise PermissionError(f"audit log {path} is not a regular file")
+    # Only ever REMOVE bits: group-write/exec and every other-bit.  Group
+    # READ is intentional (the `adm` group reads the log), so it must not
+    # count as a violation — `& 0o077` did, which made the launcher chmod
+    # the file on every single session for no reason.
+    extra = stat.S_IMODE(st.st_mode) & 0o037
+    if extra:
+        os.chmod(path, stat.S_IMODE(st.st_mode) & ~0o037)
 
 
 def _audit(
@@ -204,7 +268,7 @@ def _audit(
     payload = json.dumps(record, sort_keys=True).encode("utf-8") + b"\n"
     fd = os.open(
         str(log_path),
-        os.O_WRONLY | os.O_APPEND | os.O_CLOEXEC,
+        os.O_WRONLY | os.O_APPEND | os.O_CLOEXEC | os.O_NOFOLLOW,
     )
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)
@@ -225,111 +289,175 @@ class JailValidationError(RuntimeError):
     file).  These are all escape attempts by definition."""
 
 
+def _ancestor_symlink(path: Path) -> Optional[Path]:
+    """Return the first component of `path` (root -> leaf, inclusive)
+    that is a symlink, or None.
+
+    This walks the REAL path components: /var, /var/lib, /var/lib/bbs,
+    /var/lib/bbs/jail.  Building candidates as `resolved / component`
+    instead would test paths INSIDE the jail, which is both useless as a
+    guard and a false positive on any merged-/usr rootfs (`<jail>/lib` is
+    a symlink in every debootstrap since Debian 12)."""
+    parts = Path(os.path.abspath(str(path))).parts
+    prefix = Path(parts[0])
+    for part in parts[1:]:
+        prefix = prefix / part
+        if prefix.is_symlink():
+            return prefix
+    return None
+
+
 def _validate_jail(jail_root: Path) -> None:
-    """Make sure the jail root is a real directory owned by root,
-    not a symlink, and contains the canonical ENiGMA½ layout."""
-    # Reject any symlink in the path.  We walk up to the first
-    # existing ancestor and check each component.
-    p = jail_root
-    real: Optional[Path] = None
-    while True:
-        try:
-            real = p.resolve(strict=False)
-            break
-        except OSError as exc:
-            if exc.errno == errno.ENOENT:
-                if p.parent == p:
-                    break
-                p = p.parent
-                continue
-            raise
-    if real is None or not real.exists():
+    """Make sure the jail root is a real directory, is not reached
+    through a symlink, and contains the canonical ENiGMA½ layout."""
+    if not jail_root.exists():
         raise JailValidationError(f"jail root {jail_root} does not exist")
-    if real.is_symlink():
-        raise JailValidationError(
-            f"jail root {jail_root} resolves to a symlink ({real})"
-        )
+    # An attacker who can write to any parent directory could redirect
+    # the root to /home and read host files, so every component from /
+    # down to the jail root itself must be a real directory.
+    link = _ancestor_symlink(jail_root)
+    if link is not None:
+        if link == Path(os.path.abspath(str(jail_root))):
+            raise JailValidationError(f"jail root {jail_root} is a symlink")
+        raise JailValidationError(f"path component {link} is a symlink")
+    real = jail_root.resolve()
     if not real.is_dir():
         raise JailValidationError(f"jail root {jail_root} is not a directory")
-    # The jail root itself must not be a symlink.  An attacker who
-    # can write to the parent directory could redirect the root to
-    # /home and read host files.
-    if jail_root.is_symlink():
-        raise JailValidationError(f"jail root {jail_root} is a symlink")
-    # Walk every path component looking for a symlink that was
-    # inserted between resolve() and open() — the launcher should
-    # detect a TOCTOU symlink swap if it happens.
-    for part in jail_root.parts:
-        candidate = real / part
-        if candidate.is_symlink():
-            raise JailValidationError(f"path component {candidate} is a symlink")
     for rel in JAIL_CANONICAL_PATHS:
         target = real / rel
-        if target.is_symlink():
-            raise JailValidationError(f"canonical file {target} is a symlink")
         if not target.exists():
             raise JailValidationError(f"missing canonical file {target}")
+        # A symlink is only an escape if it LEAVES the jail.  `bin/sh ->
+        # dash` and `lib -> usr/lib` are symlinks in every real Debian
+        # rootfs, including the one docs/D4_LOCKED_LAUNCHER.md tells the
+        # operator to debootstrap; rejecting those rejects every valid
+        # jail.  Rejecting an escaping link still blocks the real attack
+        # ("swap the BBS main for the host /bin/sh").
+        if target.is_symlink():
+            resolved = target.resolve()
+            if not resolved.is_relative_to(real):
+                raise JailValidationError(
+                    f"canonical file {target} is a symlink out of the jail ({resolved})"
+                )
 
 
-# --- Privilege drop + exec ----------------------------------------------------
+def _jail_user_uid(jail_root: Path, user: str) -> int:
+    """Return the UID of `user` in the JAIL's /etc/passwd.
+
+    systemd-nspawn resolves --user= against the container's passwd
+    database (it runs getent inside the container), so a name that only
+    exists on the host fails at spawn time with a bare 'Failed to resolve
+    user'.  Catching it here turns that into an audited refusal."""
+    passwd = jail_root.resolve() / "etc" / "passwd"
+    try:
+        text = passwd.read_text(errors="replace")
+    except OSError as exc:
+        raise JailValidationError(f"cannot read {passwd}: {exc}") from exc
+    for line in text.splitlines():
+        fields = line.split(":")
+        if len(fields) >= 3 and fields[0] == user:
+            try:
+                uid = int(fields[2])
+            except ValueError as exc:
+                raise JailValidationError(
+                    f"jail user {user!r} has a non-numeric uid in {passwd}"
+                ) from exc
+            if uid == 0:
+                raise JailValidationError(
+                    f"jail user {user!r} is UID 0 inside the jail; refusing"
+                )
+            return uid
+    raise JailValidationError(
+        f"jail user {user!r} is not in {passwd}; systemd-nspawn --user would fail"
+    )
 
 
-def _lookup_unprivileged_user(name: str, group: str) -> tuple[int, int]:
-    """Resolve the bbs user/group to numeric IDs.  Refuse if the
-    user is root or has a non-numeric UID that maps to 0."""
+# --- Host-side account guard --------------------------------------------------
+
+
+def _lookup_unprivileged_user(name: str, group: str) -> Tuple[int, int]:
+    """Resolve the bbs user/group to numeric IDs on the HOST.
+
+    Refuses UID 0.  The group is resolved through the GROUP database
+    (grp), not pwd — `pwd.getpwnam(group)` looks up a *user* of that
+    name and yields that user's primary gid, which silently disagrees
+    with the requested group whenever the two databases differ."""
     try:
         entry = pwd.getpwnam(name)
     except KeyError as exc:
         raise JailValidationError(f"unprivileged user {name!r} does not exist") from exc
     if entry.pw_uid == 0:
         raise JailValidationError(f"user {name!r} has UID 0 (root); refusing")
-    try:
-        gid_entry = pwd.getpwnam(group)
-    except KeyError:
-        # Fall back to grp.getgrnam(); if even that fails, use the
-        # user's primary GID.
-        import grp
-
+    gid = entry.pw_gid
+    if group:
         try:
-            gid_entry = pwd.getpwnam(grp.getgrgid(entry.pw_gid).gr_name)
-        except (KeyError, OSError):
-            gid_entry = entry
-    return entry.pw_uid, gid_entry.pw_gid
+            gid = grp.getgrnam(group).gr_gid
+        except KeyError:
+            # Not fatal: the gid is audit metadata (nspawn takes the gid
+            # from the jail's passwd).  But it must never be silent.
+            sys.stderr.write(
+                f"eniqma-locked: group {group!r} does not exist on the host; "
+                f"recording {name!r}'s primary gid {gid} instead\n"
+            )
+    if gid == 0:
+        raise JailValidationError(f"group {group!r} has GID 0 (root); refusing")
+    return entry.pw_uid, gid
+
+
+# --- Container argv -----------------------------------------------------------
 
 
 def _machine_name(session_id: str) -> str:
-    """A short, ASCII-safe machine name for systemd-nspawn.  Must
-    fit in 64 characters and match [a-z0-9_.-]+."""
-    safe = "".join(c if c.isalnum() or c in "._-" else "_" for c in session_id)
+    """A machine name systemd will actually accept.
+
+    Only ASCII letters, digits and '-' are valid (valid_ldh_char); a
+    machine name may not start or end with '-' and may not exceed 64
+    bytes.  Mapping the invalid characters to '_' — as an earlier
+    revision did — produces `Invalid machine name` for every real
+    session, because the production session id starts with a TTY path
+    (`/dev/ttyACM0` -> `_dev_ttyACM0`)."""
+    safe = re.sub(r"[^A-Za-z0-9]+", "-", session_id).strip("-")
     if not safe:
         safe = "anon"
-    return f"{MACHINE_NAME_PREFIX}-{safe[:48]}"
+    name = f"{MACHINE_NAME_PREFIX}-{safe}"[:MACHINE_NAME_MAX].rstrip("-")
+    return name or f"{MACHINE_NAME_PREFIX}-anon"
 
 
-def _exec_systemd_nspawn(
+def build_nspawn_argv(
     *,
     jail_root: Path,
-    bbs_uid: int,
-    bbs_gid: int,
     machine: str,
-) -> "NoReturn":
-    """Drop to bbs_uid/bbs_gid and exec systemd-nspawn.  We do not
-    return from this function; success is exec, failure is OSError
-    with a clear errno."""
-    # The nspawn options here are intentionally minimal.  Anything
-    # more permissive (e.g. --bind=/home) would let a captive user
-    # read host data.
-    argv: Sequence[str] = (
-        "/usr/bin/systemd-nspawn",
+    bbs_user: str,
+    private_users: str = DEFAULT_PRIVATE_USERS,
+) -> Tuple[str, ...]:
+    """The exact argv for the container.  Pure function so the tests can
+    check it against systemd-nspawn's real option table.
+
+    The nspawn options here are intentionally minimal.  Anything more
+    permissive (e.g. --bind=/home) would let a captive user read host
+    data.  Two traps, both of which used to make this argv unrunnable:
+
+      * there is no --group= option (systemd 244..257).  nspawn takes
+        the gid from the jail passwd entry of --user=.
+      * --boot may not be combined with --as-pid2, and --boot would in
+        any case run the container's init and pass the trailing words to
+        it as kernel-command-line arguments instead of executing them.
+    """
+    argv = [
+        NSPAWN_BIN,
         "--quiet",
         "--as-pid2",
         f"--machine={machine}",
         f"--directory={jail_root}",
-        f"--user={bbs_uid}",
-        f"--group={bbs_gid}",
+    ]
+    if private_users and private_users.lower() not in ("off", "no", "none", ""):
+        # container UID 0 -> host UID <base>: root inside the jail is an
+        # unprivileged nobody outside it.
+        argv.append(f"--private-users={private_users}")
+    argv += [
+        f"--user={bbs_user}",
         # No --share-system, no --bind=, no --overlay, no --tmpfs=.
         # The jail must be self-contained.
-        "--boot",  # run an actual init in the container
         "--",
         "/usr/bin/env",
         "-i",  # ignore inherited environment
@@ -337,23 +465,92 @@ def _exec_systemd_nspawn(
         "TERM=dumb",
         "node",
         "/bbs/enigma-bbs.js",
-    )
-    os.execv(argv[0], list(argv))
+    ]
+    return tuple(argv)
+
+
+def run_container(argv: Sequence[str]) -> Tuple[int, Optional[int]]:
+    """Fork, run `argv`, forward one termination signal, wait.
+
+    Returns (exit_status, exec_errno).  exec_errno is not None when the
+    child could not exec at all — that used to be unobservable: os.execv()
+    SUCCEEDS whenever the binary exists, so the caller was replaced and
+    could never write the closing audit record, no matter how the
+    container itself failed."""
+    err_r, err_w = os.pipe2(os.O_CLOEXEC)
+    pid = os.fork()
+    if pid == 0:  # child
+        try:
+            os.close(err_r)
+            os.execv(argv[0], list(argv))
+        except OSError as exc:  # noqa: BLE001 - relayed to the parent below
+            try:
+                os.write(err_w, str(exc.errno or errno.ENOEXEC).encode("ascii"))
+            except OSError:
+                pass
+        os._exit(127)
+
+    os.close(err_w)
+    forwarded = {"done": False}
+
+    def _forward(signum: int, _frame: Any) -> None:
+        if forwarded["done"]:
+            return
+        forwarded["done"] = True
+        try:
+            os.kill(pid, signum)
+        except ProcessLookupError:
+            pass
+
+    previous = {}
+    for sig in FORWARDED_SIGNALS:
+        try:
+            previous[sig] = signal.signal(sig, _forward)
+        except (OSError, ValueError):  # pragma: no cover - restricted env
+            pass
+    try:
+        raw = b""
+        try:
+            raw = os.read(err_r, 16)
+        except OSError:
+            pass
+        finally:
+            os.close(err_r)
+        while True:
+            try:
+                _, status = os.waitpid(pid, 0)
+                break
+            except InterruptedError:  # a forwarded signal hit our wait
+                continue
+    finally:
+        for sig, handler in previous.items():
+            try:
+                signal.signal(sig, handler)
+            except (OSError, ValueError):  # pragma: no cover
+                pass
+
+    exec_errno = int(raw) if raw.strip().isdigit() else None
+    if os.WIFSIGNALED(status):
+        return 128 + os.WTERMSIG(status), exec_errno
+    return os.WEXITSTATUS(status), exec_errno
 
 
 # --- Top-level orchestration --------------------------------------------------
 
 
+def _tty_name() -> str:
+    """The dial-in line, e.g. /dev/ttyACM0.  '?' when stdin is not a tty
+    (systemd/SSH invocation, or the test harness)."""
+    try:
+        return os.ttyname(0) or "?"
+    except OSError:
+        return "?"
+
+
 def _session_id_from_env() -> str:
     """Build a session id from the TTY + pid.  Stable for the life of
     this process, never reused."""
-    tty = "unknown"
-    try:
-        tty = os.ttyname(0) or "unknown"
-    except OSError:
-        pass
-    base = f"{tty}-{os.getpid()}-{int(time.time())}"
-    return base
+    return f"{_tty_name()}-{os.getpid()}-{int(time.time())}"
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -362,38 +559,55 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     session_id = args.session_id or _session_id_from_env()
     machine = _machine_name(session_id)
     started_at = time.time()
+    tty = _tty_name()
 
-    # Capture the caller environment for the audit record before we
-    # drop privileges.  We only record SAFE keys — never $SHELL or
-    # anything the user could have set from the dial-in prompt.
+    if args.print_argv:
+        for word in build_nspawn_argv(
+            jail_root=args.jail_root,
+            machine=machine,
+            bbs_user=args.bbs_user,
+            private_users=args.private_users,
+        ):
+            sys.stdout.write(word + "\n")
+        return 0
+
+    # Capture the caller environment for the audit record.  We only
+    # record SAFE keys — never $SHELL or anything the user could have
+    # set from the dial-in prompt.  CALLER_ID is exported by mgetty and
+    # is the closest thing to a peer address a phone line has.
     safe_env_keys = ("TERM", "LANG")
     captured_env = {k: os.environ.get(k, "") for k in safe_env_keys}
+    caller_id = os.environ.get("CALLER_ID", "")
 
-    # Step 1: validate the jail.
-    try:
-        _validate_jail(args.jail_root)
-    except JailValidationError as exc:
-        sys.stderr.write(f"eniqma-locked: refusing to start: {exc}\n")
+    def _refuse(reason: str, *, extra: Optional[Dict[str, Any]] = None) -> int:
+        sys.stderr.write(f"eniqma-locked: refusing to start: {reason}\n")
+        record = {
+            "event": "refused",
+            "reason": reason,
+            "session_id": session_id,
+            "pid": os.getpid(),
+            "ppid": os.getppid(),
+            "tty": tty,
+            "caller_id": caller_id,
+            "term": captured_env.get("TERM", ""),
+            "argv0": sys.argv[0] if sys.argv else "?",
+        }
+        record.update(extra or {})
         # Audit the refusal before we exit.  We cannot guarantee the
         # audit log is reachable (a captive user may have remounted
         # the FS) but we try.
         try:
             _ensure_audit_log(args.audit_log)
-            _audit(
-                args.audit_log,
-                {
-                    "event": "refused",
-                    "reason": str(exc),
-                    "session_id": session_id,
-                    "pid": os.getpid(),
-                    "ppid": os.getppid(),
-                    "tty": captured_env.get("TERM", "?"),
-                    "argv0": sys.argv[0] if sys.argv else "?",
-                },
-            )
+            _audit(args.audit_log, record)
         except OSError:
             pass
         return 75  # EX_TEMPFAIL — mgetty will hang up.
+
+    # Step 1: validate the jail.
+    try:
+        _validate_jail(args.jail_root)
+    except JailValidationError as exc:
+        return _refuse(str(exc))
 
     # Step 2: ensure the audit log is in place.  Fail closed if we
     # cannot write to it; the operator must fix the log path before
@@ -404,27 +618,25 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         sys.stderr.write(f"eniqma-locked: cannot open audit log: {exc}\n")
         return 75
 
-    # Step 2.5: resolve the bbs user/group.  Failures here are
-    # configuration errors and must be audited before we exit.
+    # Step 2.5: resolve the accounts and the container manager.  Failures
+    # here are configuration errors and must be audited before we exit.
     try:
         bbs_uid, bbs_gid = _lookup_unprivileged_user(args.bbs_user, args.bbs_group)
+        jail_uid = _jail_user_uid(args.jail_root, args.bbs_user)
     except JailValidationError as exc:
-        sys.stderr.write(f"eniqma-locked: refusing to start: {exc}\n")
-        _audit(
-            args.audit_log,
-            {
-                "event": "refused",
-                "reason": str(exc),
-                "session_id": session_id,
-                "pid": os.getpid(),
-                "ppid": os.getppid(),
-                "argv0": sys.argv[0] if sys.argv else "?",
-            },
-        )
-        return 75
+        return _refuse(str(exc))
+    if not args.dry_run and not os.access(NSPAWN_BIN, os.X_OK):
+        return _refuse(f"{NSPAWN_BIN} is missing or not executable (apt install systemd-container)")
 
-    # Step 3: write the "start" audit record BEFORE exec.  This is
-    # the moment the user is committed to the BBS — if the BBS
+    nspawn_argv = build_nspawn_argv(
+        jail_root=args.jail_root,
+        machine=machine,
+        bbs_user=args.bbs_user,
+        private_users=args.private_users,
+    )
+
+    # Step 3: write the "start" audit record BEFORE running the BBS.
+    # This is the moment the user is committed to the BBS — if the BBS
     # crashes 1ms later we still know the session happened.
     _audit(
         args.audit_log,
@@ -434,11 +646,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             "machine": machine,
             "pid": os.getpid(),
             "ppid": os.getppid(),
+            "tty": tty,
+            "caller_id": caller_id,
             "bbs_uid": bbs_uid,
             "bbs_gid": bbs_gid,
+            "jail_uid": jail_uid,
             "jail_root": str(args.jail_root.resolve()),
             "env": captured_env,
             "argv0": sys.argv[0] if sys.argv else "?",
+            "nspawn_argv": list(nspawn_argv),
             "started_at": started_at,
         },
     )
@@ -452,28 +668,32 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         )
         return 0
 
-    # Step 4: drop privileges and exec.  systemd-nspawn will fork
-    # a child init; we become the parent of the container's PID 1.
-    try:
-        _exec_systemd_nspawn(
-            jail_root=args.jail_root,
-            bbs_uid=bbs_uid,
-            bbs_gid=bbs_gid,
-            machine=machine,
-        )
-    except OSError as exc:
-        # The exec failed.  Audit the failure, then return 71
-        # (EX_OSERR) so mgetty hangs up.
+    # Step 4: run the container, wait for it, record how it ended.
+    status, exec_errno = run_container(nspawn_argv)
+    if exec_errno is not None:
         _audit(
             args.audit_log,
             {
                 "event": "exec_failed",
                 "session_id": session_id,
-                "errno": exc.errno,
-                "errstr": os.strerror(exc.errno) if exc.errno else str(exc),
+                "machine": machine,
+                "errno": exec_errno,
+                "errstr": os.strerror(exec_errno),
             },
         )
-        return 71
+        return 71  # EX_OSERR
+    _audit(
+        args.audit_log,
+        {
+            "event": "exit",
+            "session_id": session_id,
+            "machine": machine,
+            "status": status,
+            "started_at": started_at,
+            "ended_at": time.time(),
+        },
+    )
+    return status
 
 
 if __name__ == "__main__":

--- a/launchers/eniqma-locked.service
+++ b/launchers/eniqma-locked.service
@@ -14,10 +14,13 @@
 #       for the exact logrotate snippet).
 #
 # Why a unit file at all?  Three reasons:
-#   1. The launcher's own --drop-capabilities step benefits
-#      from a tightly scoped CapabilityBoundingSet.  We set
-#      that here so an operator reading the unit can see
-#      exactly which capabilities the launcher can use.
+#   1. systemd-nspawn needs CAP_SYS_ADMIN to build the
+#      namespaces, so the launcher stays privileged until it
+#      forks; the unprivileged account is applied by nspawn's
+#      --user= inside the jail.  The CapabilityBoundingSet
+#      below is what bounds that window, so an operator
+#      reading the unit can see exactly which capabilities
+#      the launcher can use.
 #   2. `systemd-nspawn` itself looks for a matching unit in
 #      /etc/systemd/nspawn/ when --machine= is used.  An
 #      operator who prefers a unit-driven flow can copy this
@@ -37,8 +40,12 @@ RefuseManualStop=true
 Type=oneshot
 RemainAfterExit=no
 EnvironmentFile=/etc/bbs/launcher.env
-ExecStart=/usr/local/bin/eniqma-locked --dry-run
-# No ExecReload, no ExecStop — the launcher is exec-and-exit.
+# --dry-run here would validate and exit WITHOUT starting the BBS; the
+# real per-session invocation comes from mgetty (see
+# config/launchers/eniqma-locked.conf).
+ExecStart=/usr/local/bin/eniqma-locked --jail-root /var/lib/bbs/jail --bbs-user bbs --audit-log /var/log/bbs-launcher/audit.jsonl
+# No ExecReload, no ExecStop — the launcher runs the container as its
+# child and exits with the container's status.
 User=root
 Group=root
 
@@ -53,8 +60,9 @@ CapabilityBoundingSet=CAP_SYS_ADMIN CAP_SETUID CAP_SETGID CAP_DAC_OVERRIDE CAP_C
 AmbientCapabilities=CAP_SYS_ADMIN
 NoNewPrivileges=no
 # The launcher is a thin wrapper; the real isolation is in
-# systemd-nspawn.  The private /tmp /dev is enforced by
-# nspawn's --private-users, not by this unit.
+# systemd-nspawn.  The private /tmp and /dev come from nspawn's
+# mount namespace, and container root is shifted off host root by
+# --private-users=, not by this unit.
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true

--- a/tests/test_eniqma_locked.py
+++ b/tests/test_eniqma_locked.py
@@ -75,9 +75,12 @@ def _build_minimal_jail(root: Path) -> None:
     (root / "etc").mkdir(exist_ok=True)
     (root / "bbs").mkdir(exist_ok=True)
     (root / "bin").mkdir(exist_ok=True)
-    # /etc/passwd: just a single comment line, enough to satisfy
-    # the existence check.
-    (root / "etc" / "passwd").write_text("root:x:0:0:root:/:/bin/sh\n")
+    # /etc/passwd: root plus the BBS account.  systemd-nspawn resolves
+    # --user= against the JAIL's passwd (it runs getent inside the
+    # container), so the launcher pre-checks it here too.
+    (root / "etc" / "passwd").write_text(
+        "root:x:0:0:root:/:/bin/sh\n" f"{BBS_USER}:x:999:999:bbs:/bbs:/bin/sh\n"
+    )
     # /bbs/enigma-bbs.js: a placeholder JS file (real ENiGMA½
     # ships a much larger main, but the launcher only checks
     # that the path exists).

--- a/tests/test_eniqma_locked_exec.py
+++ b/tests/test_eniqma_locked_exec.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+#
+# tests/test_eniqma_locked_exec.py — Bounty D4, the half that
+# tests/test_eniqma_locked.py cannot reach.
+#
+# Every test in the original suite runs the launcher with --dry-run,
+# which returns before the container is ever built.  That is why the
+# launcher could ship with an exec that systemd-nspawn rejects three
+# different ways while all 13 cases stayed green.  This file tests the
+# things that only matter once --dry-run is off:
+#
+#   * the systemd-nspawn argv is one the real option parser accepts,
+#   * the machine name is one systemd's machine_name_is_valid() accepts,
+#   * the jail validation accepts a real (merged-/usr) Debian rootfs and
+#     still rejects the escape it is there to block,
+#   * the launcher observes and records how the container ended.
+#
+# The oracles are deliberately independent of the launcher: the option
+# table is read from `systemd-nspawn --help` when it is installed (and
+# from a transcribed table when it is not), and hostname validity is a
+# line-by-line transcription of systemd's own hostname_is_valid().
+from __future__ import annotations
+
+import errno
+import importlib.util
+import json
+import os
+import pwd
+import grp
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+LAUNCHER = Path(__file__).resolve().parent.parent / "launchers" / "eniqma-locked.py"
+
+
+def _load_launcher():
+    """Import the launcher by path (its filename is not a module name)."""
+    spec = importlib.util.spec_from_file_location("eniqma_locked", LAUNCHER)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+el = _load_launcher()
+
+
+def _pick_test_user() -> str:
+    for name in ("nobody", "bbs", "games"):
+        try:
+            if pwd.getpwnam(name).pw_uid != 0:
+                return name
+        except KeyError:
+            continue
+    me = pwd.getpwuid(os.getuid())
+    if me.pw_uid == 0:
+        pytest.skip("no non-root system user available on this runner")
+    return me.pw_name
+
+
+BBS_USER = _pick_test_user()
+
+
+def _build_jail(root: Path, *, user: str = BBS_USER, uid: int = 999) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    for d in ("etc", "bbs", "bin"):
+        (root / d).mkdir(exist_ok=True)
+    (root / "etc" / "passwd").write_text(
+        "root:x:0:0:root:/:/bin/sh\n" f"{user}:x:{uid}:{uid}:bbs:/bbs:/bin/sh\n"
+    )
+    (root / "bbs" / "enigma-bbs.js").write_text("// placeholder\n")
+    (root / "bin" / "sh").write_text("#!/bin/false\n")
+    (root / "bin" / "sh").chmod(0o755)
+    return root
+
+
+# --------------------------------------------------------------------------- #
+# 1. The systemd-nspawn argv
+# --------------------------------------------------------------------------- #
+
+# Long options accepted by systemd-nspawn.  Read from the installed
+# binary when present; this transcription (systemd 255, and unchanged in
+# 244..257 for every option used here) keeps the test meaningful on a
+# runner without systemd-container.  NOTE what is NOT here: --group.
+NSPAWN_LONG_OPTIONS = {
+    "--ambient-capability", "--as-pid2", "--bind", "--bind-ro", "--bind-user",
+    "--boot", "--capability", "--chdir", "--console", "--cpu-affinity",
+    "--directory", "--drop-capability", "--ephemeral", "--help", "--hostname",
+    "--image", "--image-policy", "--inaccessible", "--keep-unit", "--kill-signal",
+    "--link-journal", "--load-credential", "--machine", "--network-bridge",
+    "--network-interface", "--network-ipvlan", "--network-macvlan",
+    "--network-namespace-path", "--network-veth", "--network-veth-extra",
+    "--network-zone", "--no-new-privileges", "--no-pager", "--notify-ready",
+    "--oci-bundle", "--oom-score-adjust", "--overlay", "--overlay-ro",
+    "--personality", "--pipe", "--pivot-root", "--port", "--private-network",
+    "--private-users", "--private-users-ownership", "--property", "--quiet",
+    "--read-only", "--register", "--resolv-conf", "--rlimit", "--root-hash",
+    "--root-hash-sig", "--selinux-apifs-context", "--selinux-context",
+    "--set-credential", "--settings", "--slice", "--suppress-sync",
+    "--system-call-filter", "--template", "--timezone", "--tmpfs", "--user",
+    "--uuid", "--verity-data", "--version", "--volatile",
+}
+
+
+def _live_option_table() -> Optional[set]:
+    """The option table of the systemd-nspawn actually installed here."""
+    if not shutil.which("systemd-nspawn"):
+        return None
+    out = subprocess.run(
+        ["systemd-nspawn", "--help"], capture_output=True, text=True, timeout=20
+    )
+    text = out.stdout + out.stderr
+    opts = set()
+    for token in text.replace("=", " ").replace(",", " ").split():
+        if token.startswith("--") and len(token) > 2:
+            opts.add(token.rstrip("[]|"))
+    return opts or None
+
+
+def _argv(**kw):
+    kw.setdefault("jail_root", Path("/var/lib/bbs/jail"))
+    kw.setdefault("machine", "bbs-dev-ttyACM0-1234-1785000000")
+    kw.setdefault("bbs_user", "bbs")
+    return el.build_nspawn_argv(**kw)
+
+
+def _options_of(argv) -> list:
+    """Long options before the `--` separator."""
+    out = []
+    for word in argv[1:]:
+        if word == "--":
+            break
+        if word.startswith("--"):
+            out.append(word.split("=", 1)[0])
+    return out
+
+
+def test_every_option_exists_in_nspawn() -> None:
+    """Every long option we pass must be in systemd-nspawn's option
+    table.  `--group=` is not, and nspawn dies at option parsing:
+    `systemd-nspawn: unrecognized option '--group=999'`."""
+    table = _live_option_table() or NSPAWN_LONG_OPTIONS
+    unknown = [o for o in _options_of(_argv()) if o not in table]
+    assert unknown == [], f"systemd-nspawn does not know {unknown}"
+
+
+def test_boot_and_as_pid2_are_not_combined() -> None:
+    """`--boot and --as-pid2 may not be combined.` — systemd-nspawn
+    refuses the pair outright, and --boot would in any case hand the
+    trailing words to the container's init as kernel-command-line
+    arguments instead of executing them."""
+    opts = _options_of(_argv())
+    assert not ("--boot" in opts and "--as-pid2" in opts)
+
+
+def test_argv_runs_the_bbs_as_the_container_payload() -> None:
+    argv = _argv()
+    sep = argv.index("--")
+    assert argv[sep + 1 :] == (
+        "/usr/bin/env",
+        "-i",
+        "HOME=/bbs",
+        "TERM=dumb",
+        "node",
+        "/bbs/enigma-bbs.js",
+    )
+    assert argv[0] == el.NSPAWN_BIN
+    # No shell, no metacharacters, nothing interpolated from the caller.
+    assert not any(c in w for w in argv for c in ";|&$`\n")
+
+
+def test_user_is_passed_by_name_not_host_uid() -> None:
+    """nspawn resolves --user= inside the container (it runs getent in
+    the jail).  A host uid is meaningless there: the jail ships its own
+    /etc/passwd where bbs is 999 regardless of the host's numbering."""
+    argv = _argv(bbs_user="bbs")
+    assert "--user=bbs" in argv
+    assert not any(w.startswith("--user=") and w[7:].isdigit() for w in argv)
+
+
+def test_private_users_default_and_opt_out() -> None:
+    assert f"--private-users={el.DEFAULT_PRIVATE_USERS}" in _argv()
+    assert not any(w.startswith("--private-users") for w in _argv(private_users="off"))
+
+
+@pytest.mark.skipif(not shutil.which("systemd-nspawn"), reason="systemd-nspawn not installed")
+def test_nspawn_accepts_our_argv(tmp_path: Path) -> None:
+    """Hand the real binary our real argv.  Option parsing and machine
+    name validation happen before nspawn needs privileges, so this runs
+    unprivileged; we only assert it does not die in the parser."""
+    jail = _build_jail(tmp_path / "jail")
+    argv = list(
+        _argv(jail_root=jail, machine=el._machine_name("/dev/ttyACM0-2411-1785000000"))
+    )
+    out = subprocess.run(argv, capture_output=True, text=True, timeout=60)
+    blob = (out.stdout + out.stderr).lower()
+    for fatal in ("unrecognized option", "may not be combined", "invalid machine name"):
+        assert fatal not in blob, f"systemd-nspawn rejected our argv: {out.stderr.strip()}"
+
+
+# --------------------------------------------------------------------------- #
+# 2. The machine name
+# --------------------------------------------------------------------------- #
+
+
+def _valid_ldh_char(c: str) -> bool:
+    return c.isascii() and (c.isalnum() or c == "-")
+
+
+def hostname_is_valid(s: str) -> bool:
+    """Transcription of systemd's hostname_is_valid(s, 0)
+    (src/basic/hostname-util.c, v255) — the check behind
+    machine_name_is_valid(), i.e. behind `--machine=`."""
+    if not s:
+        return False
+    dot = hyphen = True
+    n_dots = 0
+    for ch in s:
+        if ch == ".":
+            if dot or hyphen:
+                return False
+            dot, hyphen = True, False
+            n_dots += 1
+        elif ch == "-":
+            if dot:
+                return False
+            dot, hyphen = False, True
+        else:
+            if not _valid_ldh_char(ch):
+                return False
+            dot = hyphen = False
+    if dot:
+        return False
+    if hyphen:
+        return False
+    return len(s.encode()) <= 64  # HOST_NAME_MAX
+
+
+@pytest.mark.parametrize(
+    "session_id",
+    [
+        "/dev/ttyACM0-2411-1785000000",  # the production shape
+        "/dev/ttyS1-9-1",
+        "weird!@# session$id",
+        "unknown-1-1",
+        "....",
+        "---",
+        "",
+        "ünïcödé-tty",
+        "x" * 200,
+        "/dev/pts/3-1-1",
+    ],
+)
+def test_machine_name_is_valid_for_systemd(session_id: str) -> None:
+    """`_machine_name` mapped every invalid character to '_', but '_' is
+    not a valid_ldh_char: systemd answers `Invalid machine name:
+    bbs-_dev_ttyACM0-...`.  Since the production session id always
+    starts with a TTY path, that fired on every single dial-in."""
+    name = el._machine_name(session_id)
+    assert hostname_is_valid(name), f"systemd would reject {name!r}"
+    assert name.startswith("bbs-")
+    assert "_" not in name
+
+
+@pytest.mark.skipif(not shutil.which("systemd-nspawn"), reason="systemd-nspawn not installed")
+def test_machine_name_accepted_by_systemd(tmp_path: Path) -> None:
+    jail = _build_jail(tmp_path / "jail")
+    name = el._machine_name("/dev/ttyACM0-2411-1785000000")
+    out = subprocess.run(
+        ["systemd-nspawn", "--quiet", f"--machine={name}", f"--directory={jail}",
+         "--", "/bin/true"],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert "invalid machine name" not in (out.stdout + out.stderr).lower()
+
+
+# --------------------------------------------------------------------------- #
+# 3. Jail validation
+# --------------------------------------------------------------------------- #
+
+
+def test_symlinked_ancestor_of_the_jail_is_rejected(tmp_path: Path) -> None:
+    """The documented attack: "an attacker who can write to the parent
+    directory could redirect the root to /home".  The old check built
+    its candidates as `resolved_jail / component`, so it inspected
+    <jail>/var, <jail>/lib, <jail>/bbs — paths inside the jail — and
+    never looked at a single real ancestor."""
+    evil = tmp_path / "evil"
+    _build_jail(evil / "jail")
+    os.symlink(evil, tmp_path / "bbs")  # attacker-controlled component
+    with pytest.raises(el.JailValidationError) as exc:
+        el._validate_jail(tmp_path / "bbs" / "jail")
+    assert "symlink" in str(exc.value)
+
+
+def test_merged_usr_rootfs_is_accepted(tmp_path: Path) -> None:
+    """docs/D4_LOCKED_LAUNCHER.md tells the operator to
+    `debootstrap --variant=minbase stable /var/lib/bbs/jail`.  Every
+    Debian since 12 is merged-/usr, so that jail has `lib -> usr/lib`
+    and `bin/sh -> dash`; and the default jail root has a component
+    named `lib`.  The old validator refused both."""
+    jail = tmp_path / "var" / "lib" / "bbs" / "jail"
+    _build_jail(jail)
+    (jail / "usr" / "lib").mkdir(parents=True)
+    (jail / "lib").rmdir() if (jail / "lib").is_dir() else None
+    os.symlink("usr/lib", jail / "lib")
+    # bin/sh -> dash, exactly as a real rootfs ships it
+    (jail / "bin" / "sh").unlink()
+    (jail / "bin" / "dash").write_text("#!/bin/false\n")
+    os.symlink("dash", jail / "bin" / "sh")
+    el._validate_jail(jail)  # must not raise
+
+
+def test_canonical_symlink_out_of_the_jail_is_rejected(tmp_path: Path) -> None:
+    jail = _build_jail(tmp_path / "jail")
+    (jail / "bbs" / "enigma-bbs.js").unlink()
+    os.symlink("/bin/sh", jail / "bbs" / "enigma-bbs.js")
+    with pytest.raises(el.JailValidationError) as exc:
+        el._validate_jail(jail)
+    assert "symlink" in str(exc.value)
+
+
+def test_missing_jail_user_is_refused_before_spawn(tmp_path: Path) -> None:
+    """nspawn resolves --user in the jail; a name that is only on the
+    host fails with a bare `Failed to resolve user bbs`."""
+    jail = _build_jail(tmp_path / "jail")
+    (jail / "etc" / "passwd").write_text("root:x:0:0:root:/:/bin/sh\n")
+    with pytest.raises(el.JailValidationError) as exc:
+        el._jail_user_uid(jail, "bbs")
+    assert "not in" in str(exc.value)
+
+
+def test_jail_user_with_uid_zero_is_refused(tmp_path: Path) -> None:
+    jail = _build_jail(tmp_path / "jail")
+    (jail / "etc" / "passwd").write_text("bbs:x:0:0:bbs:/bbs:/bin/sh\n")
+    with pytest.raises(el.JailValidationError) as exc:
+        el._jail_user_uid(jail, "bbs")
+    assert "UID 0" in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
+# 4. Host account resolution
+# --------------------------------------------------------------------------- #
+
+
+def test_group_is_resolved_through_the_group_database() -> None:
+    """`pwd.getpwnam(group)` looks up a *user*.  With --bbs-group adm it
+    returned nobody's primary gid (65534) instead of adm's gid (4), and
+    the original suite could not see it because it passes
+    BBS_GROUP = BBS_USER."""
+    try:
+        adm = grp.getgrnam("adm").gr_gid
+    except KeyError:  # pragma: no cover - runner without an adm group
+        pytest.skip("no adm group on this runner")
+    uid, gid = el._lookup_unprivileged_user(BBS_USER, "adm")
+    assert gid == adm
+    assert uid == pwd.getpwnam(BBS_USER).pw_uid
+
+
+def test_unknown_group_warns_and_falls_back(capsys) -> None:
+    uid, gid = el._lookup_unprivileged_user(BBS_USER, "no-such-group-xyzzy")
+    assert gid == pwd.getpwnam(BBS_USER).pw_gid
+    assert "does not exist" in capsys.readouterr().err
+
+
+def test_root_group_is_refused() -> None:
+    root_group = grp.getgrgid(0).gr_name
+    with pytest.raises(el.JailValidationError):
+        el._lookup_unprivileged_user(BBS_USER, root_group)
+
+
+# --------------------------------------------------------------------------- #
+# 5. Audit log permissions
+# --------------------------------------------------------------------------- #
+
+
+def _umask(value: int):
+    old = os.umask(value)
+    return old
+
+
+def test_created_log_is_0640_under_any_umask(tmp_path: Path) -> None:
+    """os.open()'s mode argument is masked by umask.  mgetty runs with
+    022 on Debian and 077 on some hardened images; under 077 the log was
+    created 0600 and `adm` could not read it (and the original
+    test_audit_log_permission_strict passed only by luck, because the
+    over-eager chmod below happened to fire under umask 022)."""
+    old = _umask(0o077)
+    try:
+        log = tmp_path / "a.jsonl"
+        el._ensure_audit_log(log)
+        assert stat.S_IMODE(log.stat().st_mode) == 0o640
+    finally:
+        os.umask(old)
+
+
+def test_symlink_swapped_after_the_first_check(tmp_path: Path, monkeypatch) -> None:
+    """The second gate — "became a symlink between checks" — used
+    `path.stat()`, which follows the link, so `S_ISLNK` on its result can
+    never be true.  Here the first gate is neutered to simulate winning
+    the race; only an `lstat` catches it."""
+    real = tmp_path / "real.jsonl"
+    el._ensure_audit_log(real)
+    link = tmp_path / "link.jsonl"
+    os.symlink(real, link)
+    monkeypatch.setattr(Path, "is_symlink", lambda self: False)
+    with pytest.raises(PermissionError) as exc:
+        el._ensure_audit_log(link)
+    assert "symlink" in str(exc.value)
+
+
+def test_existing_stricter_log_is_kept(tmp_path: Path) -> None:
+    """An operator who tightened the log to 0600 keeps it: the mode
+    fix-up may only remove bits, never add them."""
+    log = tmp_path / "a.jsonl"
+    el._ensure_audit_log(log)
+    os.chmod(log, 0o600)
+    el._ensure_audit_log(log)
+    assert stat.S_IMODE(log.stat().st_mode) == 0o600
+
+
+def test_group_writable_log_is_tightened(tmp_path: Path) -> None:
+    log = tmp_path / "a.jsonl"
+    el._ensure_audit_log(log)
+    os.chmod(log, 0o666)
+    el._ensure_audit_log(log)
+    mode = stat.S_IMODE(log.stat().st_mode)
+    assert mode & 0o037 == 0, oct(mode)
+
+
+def test_symlinked_log_is_refused(tmp_path: Path) -> None:
+    real = tmp_path / "real.jsonl"
+    el._ensure_audit_log(real)
+    link = tmp_path / "link.jsonl"
+    os.symlink(real, link)
+    with pytest.raises(PermissionError):
+        el._ensure_audit_log(link)
+
+
+# --------------------------------------------------------------------------- #
+# 6. Running the container and recording how it ended
+# --------------------------------------------------------------------------- #
+
+
+def test_run_container_reports_exit_status() -> None:
+    status, exec_errno = el.run_container(["/bin/sh", "-c", "exit 42"])
+    assert (status, exec_errno) == (42, None)
+
+
+def test_exec_failure_is_observable() -> None:
+    """os.execv() succeeds whenever the binary exists, so the old
+    `except OSError -> audit exec_failed` branch could only ever fire
+    when systemd-nspawn was missing entirely; every failure OF the
+    container was invisible, and the audit log's last word for a dead
+    session was `"event": "start"`."""
+    status, exec_errno = el.run_container(["/nonexistent/systemd-nspawn"])
+    assert exec_errno == errno.ENOENT
+    assert status == 127
+
+
+def test_hangup_is_forwarded_to_the_container() -> None:
+    """mgetty drops DTR when the caller hangs up; the launcher now has a
+    child to pass that on to."""
+    old = signal.getsignal(signal.SIGHUP)
+    # Park a no-op handler first: the default disposition for SIGHUP is
+    # "terminate", so a launcher that does NOT install its own handler
+    # must fail this assertion instead of killing the test session.
+    signal.signal(signal.SIGHUP, lambda *_: None)
+    # A helper process, not a thread: run_container() forks, and forking
+    # a multi-threaded process is what the launcher must not do.
+    hup = subprocess.Popen(["/bin/sh", "-c", f"sleep 0.4; kill -HUP {os.getpid()}"])
+    try:
+        status, exec_errno = el.run_container(["/bin/sleep", "5"])
+    finally:
+        hup.wait(timeout=10)
+        signal.signal(signal.SIGHUP, old)
+    assert exec_errno is None
+    assert status == 128 + signal.SIGHUP
+
+
+def test_session_start_and_exit_are_both_audited(tmp_path: Path, monkeypatch) -> None:
+    jail = _build_jail(tmp_path / "jail")
+    log = tmp_path / "audit.jsonl"
+    monkeypatch.setattr(el, "NSPAWN_BIN", "/bin/true")
+    rc = el.main(
+        [
+            "--jail-root", str(jail),
+            "--bbs-user", BBS_USER,
+            "--bbs-group", BBS_USER,
+            "--audit-log", str(log),
+            "--session-id", "sess-1",
+        ]
+    )
+    events = [json.loads(line) for line in log.read_text().splitlines()]
+    assert [e["event"] for e in events] == ["start", "exit"]
+    assert rc == 0 and events[1]["status"] == 0
+    assert events[1]["ended_at"] >= events[0]["started_at"]
+    # The start record must carry the line, not just $TERM under a key
+    # called "tty".
+    assert "tty" in events[0] and "caller_id" in events[0]
+    assert events[0]["jail_uid"] == 999
+
+
+def test_failing_container_is_audited_with_its_status(tmp_path: Path, monkeypatch) -> None:
+    jail = _build_jail(tmp_path / "jail")
+    log = tmp_path / "audit.jsonl"
+    monkeypatch.setattr(el, "NSPAWN_BIN", "/bin/false")
+    rc = el.main(
+        [
+            "--jail-root", str(jail),
+            "--bbs-user", BBS_USER,
+            "--bbs-group", BBS_USER,
+            "--audit-log", str(log),
+            "--session-id", "sess-2",
+        ]
+    )
+    events = [json.loads(line) for line in log.read_text().splitlines()]
+    assert rc == 1
+    assert events[-1]["event"] == "exit" and events[-1]["status"] == 1
+
+
+def test_missing_nspawn_is_refused_not_discovered_as_a_dead_line(
+    tmp_path: Path, monkeypatch
+) -> None:
+    jail = _build_jail(tmp_path / "jail")
+    log = tmp_path / "audit.jsonl"
+    monkeypatch.setattr(el, "NSPAWN_BIN", "/nonexistent/systemd-nspawn")
+    rc = el.main(
+        [
+            "--jail-root", str(jail),
+            "--bbs-user", BBS_USER,
+            "--audit-log", str(log),
+            "--session-id", "sess-3",
+        ]
+    )
+    assert rc == 75
+    record = json.loads(log.read_text().splitlines()[-1])
+    assert record["event"] == "refused" and "systemd-nspawn" in record["reason"]
+
+
+def test_print_argv_is_greppable_by_an_operator(tmp_path: Path) -> None:
+    jail = _build_jail(tmp_path / "jail")
+    out = subprocess.run(
+        [sys.executable, str(LAUNCHER), "--jail-root", str(jail),
+         "--session-id", "print", "--print-argv"],
+        capture_output=True, text=True, timeout=15,
+    )
+    words = out.stdout.split("\n")
+    assert out.returncode == 0
+    assert words[0] == el.NSPAWN_BIN
+    assert "--boot" not in words
+    assert not any(w.startswith("--group") for w in words)


### PR DESCRIPTION
## The D4 launcher cannot start the BBS — and the audit log says it did

`launchers/eniqma-locked.py` is the only program a dial-in user reaches. Its one production path — build the container and run ENiGMA½ — fails **three** different ways, each fatal on its own. None of them can be seen by `tests/test_eniqma_locked.py`, because every one of its 13 cases passes `--dry-run`, which returns two statements before the exec.

Same jail, same command line, on a real `systemd-nspawn` (255):

```
$ python3 launchers/eniqma-locked.py --jail-root /tmp/jt2 --bbs-user nobody \
      --bbs-group nogroup --audit-log /tmp/bbslog/a.jsonl \
      --session-id "/dev/ttyACM0-4242-1785000000"
main     Invalid machine name: bbs-_dev_ttyACM0-4242-1785000000       rc=1
this PR  enigma-bbs started as 65534:65534 argv=/bbs/enigma-bbs.js    rc=0

$ tail -1 /tmp/bbslog/a.jsonl
main     {"event": "start", "machine": "bbs-_dev_ttyACM0-...", ...}   <- last word for a dead session
this PR  {"event": "exit", "status": 0, "ended_at": ..., ...}
```

**1. `--group=` is not a systemd-nspawn option.** Not in 255, not in any release 244..257 — nspawn has `-u/--user=` and no group switch at all; the container gid comes from the jail passwd entry of `--user`.

```
$ systemd-nspawn --quiet --as-pid2 --machine=bbs-t --directory=/tmp/jt \
      --user=999 --group=999 --boot -- /usr/bin/env -i ... node /bbs/enigma-bbs.js
systemd-nspawn: unrecognized option '--group=999'          (exit 1, nothing ran)
```

**2. `--boot` and `--as-pid2` are mutually exclusive.** Drop `--group=` and the next parser error appears:

```
$ systemd-nspawn --quiet --as-pid2 --machine=bbs-t --directory=/tmp/jt --user=bbs --boot -- ...
--boot and --as-pid2 may not be combined.
```

`--boot` is also the wrong verb here: it runs the container's init and passes the trailing words to *it* as kernel-command-line arguments, so `node /bbs/enigma-bbs.js` would not be executed even if the pair were allowed. The module header documents `--as-pid2 --private-users=65536 --user=bbs --chdir= --bind=` — an argv that does not appear anywhere in the file.

**3. Every real session's machine name is invalid.** `_machine_name()` maps each non-`[A-Za-z0-9._-]` character to `_`, but systemd validates machine names with `hostname_is_valid()` → `valid_ldh_char()` = letters, digits, `-` only. The production session id starts with `os.ttyname(0)`, i.e. `/dev/ttyACM0` → `_dev_ttyACM0`, so this fires on **every dial-in** (see the run above). The shipped `test_session_id_is_canonical_for_machine_name` asserts `c.isalnum() or c in "._-"` — it encodes the wrong charset, so it passes on a name systemd rejects.

**4. The failure is invisible.** `os.execv()` succeeds whenever the binary exists — the launcher is *replaced*, so the `except OSError → audit "exec_failed"` branch can only ever fire when `systemd-nspawn` is missing entirely; every failure **of** the container is unobservable. Header step 4 ("Waits for the BBS to exit and records the exit code") is impossible after `execv`: there is no `exit` event in the schema, and `BBS_STARTUP_TIMEOUT` is an unused constant. An operator greps the audit log and sees `"event": "start"` for a line where nothing ever ran.

## The jail validator rejects the documented install and passes the documented attack

```python
for part in jail_root.parts:          # ('/', 'var', 'lib', 'bbs', 'jail')
    candidate = real / part           # -> /var/lib/bbs/jail/var, .../lib, .../bbs
```

The comment above it says "walk every path component looking for a symlink", and the D4 doc maps it to *"an attacker who can write to the parent directory could redirect the root to /home"*. It walks the components of the jail path **inside the jail**. Real ancestors — `/var`, `/var/lib`, `/var/lib/bbs` — are never examined. Both directions measured:

```
A) /tmp/X/bbs -> /tmp/evil, jail root /tmp/X/bbs/jail
   main    ACCEPTED   (resolves to /tmp/evil/jail — the escape the guard exists for)
   this PR JailValidationError: path component /tmp/X/bbs is a symlink

B) jail root .../var/lib/bbs/jail, jail contains lib -> usr/lib   (any merged-/usr rootfs)
   main    REJECTED: path component .../var/lib/bbs/jail/lib is a symlink
   this PR accepted
```

Case B is not hypothetical: `docs/D4_LOCKED_LAUNCHER.md` §3.4 tells the operator to `debootstrap --variant=minbase stable /var/lib/bbs/jail`, every Debian since 12 is merged-/usr, and the *default* jail root has a component named `lib`. The canonical-file check rejects that same rootfs a second time, because `bin/sh` is a symlink to `dash` in every Debian install — as my live run above shows (`refusing to start: canonical file /tmp/jt/bin/sh is a symlink`). A symlink is only an escape if it **leaves** the jail, which is now the rule; the "swap the BBS main for the host /bin/sh" attack is still refused.

Two dead checks in the same function: `real.is_symlink()` after `real = p.resolve()` can never be true, and the `while True` loop around `resolve(strict=False)` can never take its `ENOENT` branch (`strict=False` does not raise).

## Smaller, same class

* **`--bbs-group` never resolves a group.** `pwd.getpwnam(group)` looks up a *user* of that name; `grp.getgrnam` is never called. `--bbs-group adm` → gid **65534**, not 4. Invisible to the suite because it sets `BBS_GROUP = BBS_USER`.
* **The audit log's TOCTOU gate is dead code.** `st = path.stat()` follows the link, so `stat.S_ISLNK(st.st_mode)` is always false; it needs `lstat`. Opens now also use `O_NOFOLLOW`.
* **The audit log's mode is umask-dependent.** `os.open(..., 0o640)` is masked, so under mgetty's umask 077 the log is created 0600 and the `adm` group — the whole point of 0640 root:adm — cannot read it. The shipped `test_audit_log_permission_strict` fails there: `13 passed` under umask 022, `1 failed, 12 passed` under umask 077, against unmodified `main`. Now set explicitly with `fchmod`, and the fix-up may only *remove* bits (`& 0o077` counted the intended group-read bit as a violation and chmod'd on every launch).
* **The audit record's `"tty"` is `$TERM`**, and only the refusal record has it; the header claims TTY + peer addr. Now `os.ttyname()` and mgetty's `$CALLER_ID`, on both records.
* **`--user=<host uid>`** is passed a host uid, but nspawn resolves `--user` in the **jail's** passwd (it runs `getent` inside the container). Now passed by name, and the account is pre-checked in the jail's `/etc/passwd` so a mismatch is an audited refusal instead of a bare `Failed to resolve user bbs`.
* **The header's privilege claim is not what happens.** "Drops to the unprivileged bbs user, gives up root, then execs" / "the wrapper holds CAP_SYS_ADMIN briefly and drops it before exec" — there is no `setuid`/`setgid`/`setgroups` anywhere, and there cannot be: nspawn needs CAP_SYS_ADMIN to build the namespaces. I corrected the docs rather than adding a privilege drop that would break the container. The unprivileged account is applied by nspawn `--user=`, and `--private-users=65536` (documented in the header, absent from the argv) is now actually passed, so container root maps to host 65536.
* `config/launchers/eniqma-locked.conf` reads like a config file (`BBS_USER=`, `JAIL_ROOT=`, `BBS_STARTUP_TIMEOUT=`) and the launcher reads no environment and no config file by design — the mgetty rule invoked it with no arguments, so every value there was inert. The rule now passes the flags. The shipped unit's `ExecStart=... --dry-run` would validate and exit without starting the BBS.

## Tests

37 new cases in `tests/test_eniqma_locked_exec.py`, covering exactly what `--dry-run` returns before. Oracles are independent of the launcher: the option table is read from `systemd-nspawn --help` when installed (with a transcription for runners without systemd-container), and machine-name validity is a line-by-line transcription of systemd's `hostname_is_valid()` (src/basic/hostname-util.c, v255) — plus live cross-checks against the real binary, skipped when it is absent.

```
python3 -m pytest tests/test_eniqma_locked.py tests/test_eniqma_locked_exec.py -q
  main: 13 passed (+ 37 could not exist)          this PR: 50 passed
  under umask 077 — main: 1 failed, 12 passed     this PR: 50 passed

mutation (revert ONLY launchers/eniqma-locked.py)      29 failed / 21 passed
   ▸ all 13 original cases stay green under the mutant

single-defect mutants (applied to this PR's launcher):
   re-add --group= and --boot                          4 failed
   machine name: invalid chars -> '_'                  9 failed
   ancestor walk: candidates inside the jail           3 failed
   group lookup via pwd.getpwnam                       1 failed
   audit: lstat -> stat                                1 failed
```

One line of the existing test file changed: `_build_minimal_jail` now writes the BBS account into the jail's `/etc/passwd`, because the launcher pre-checks it there. All 13 assertions are untouched.

## Honestly not fixed / not verified

* **No modem, no Pi, no ENiGMA½.** I proved the container path with a hand-built jail (busybox + a `node` shim + a real `getent`, which is what nspawn's `--user` resolution needs inside the container) and a real `systemd-nspawn` — that covers argv, machine name, user resolution, exit-status capture and the audit records. It does **not** prove ENiGMA½ itself runs, and the mgetty side (`login.config` catch-all, hangup on DTR drop) is unchanged and untested by me.
* **`--private-users=65536` shifts ownership.** It works on a root-owned tree for read-only content (verified), but ENiGMA½ writes message bases; the operator must shift the tree (`--private-users-ownership=chown`) or pass `--private-users off`. I documented that instead of guessing what the deployment wants — and I did **not** add the `--bind=/var/lib/bbs/data` the header mentions, because the bind target and its ownership under the shift are a maintainer decision.
* **`--user` resolution via NSS.** The jail pre-check reads `etc/passwd` directly; an account provided only through a container-side NSS module would be refused incorrectly. That seemed the right trade for a BBS jail, but it is a behaviour choice worth a look.
* **`TERM=dumb` is unchanged.** A BBS on `TERM=dumb` renders no ANSI, which is arguably wrong for ENiGMA½, but passing the caller's `$TERM` through is a policy change on a value the dial-in user controls — left alone deliberately.
* Pre-existing and untouched: `tests/test_d7_bigendian.py` fails 14 cases on this machine before and after my change (it needs cross-compiled big-endian binaries + qemu, neither present).

▶️ Environment: Linux x86-64, Python 3.12.3, pytest 9.1.0, systemd 255 (255.4-1ubuntu8.16), run as root. `ruff check --select F` clean on every file I touched.

Bounty: D4 (fix)
Wallet: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7
